### PR TITLE
fix for focus stuck in grid when doing backward tab navigation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slickgrid",
-  "version": "2.3.35",
+  "version": "2.3.36",
   "description": "A lightning fast JavaScript grid/spreadsheet modified for use in Azure Data Studio",
   "main": "slick.core.js",
   "directories": {

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -3706,7 +3706,6 @@ if (typeof Slick === "undefined") {
         activePosX = pos.posX;
         return true;
       } else {
-        setActiveCellInternal(getCellNode(activeRow, activeCell));
         return false;
       }
     }


### PR DESCRIPTION
Issue: 
when edit mode is on, the keyboard focus is stuck inside the grid when doing backward tab navigation, this is found while testing table designer but also observed in Edit data feature.

Root Cause:
we no target cell is identified, currently slickgrid will set current cell as active, when the edit mode is on an editor is created and focus will be in it and the backward tab will move the focus to the previous focusable element, in this case it is the cell container itself, this is an infinite loop, if you press SHIFT+TAB again, the same logic will repeat.

Fix:
Remove the code that is making the current cell as active, for editable grid, we will be able to navigate out of the grid as expected, for readonly grid, there is no impact because the setting current cell as active cell is just a no-op for the grid.
In the 'After' screenshot, I also included keyboard navigation for query editor result (forward/backward tab navigation, left, right, up, down) to make sure it still works as expected.

Screen shots

Before:  Observe that I was not able to move the focus out of grid using backward tab key navigation.
![backward-tabbing-before](https://user-images.githubusercontent.com/13777222/157952287-7264158b-673b-4141-87aa-5bd8e617e375.gif)


After:

![backward-tabbing-after](https://user-images.githubusercontent.com/13777222/157952316-8e3fef36-b741-48ec-9fbe-4a2ae4232bf7.gif)
