### PR TITLE
Removing column based virtualization in slick grid to fix screen reader issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slickgrid",
-  "version": "2.3.38",
+  "version": "2.3.39",
   "description": "A lightning fast JavaScript grid/spreadsheet modified for use in Azure Data Studio",
   "main": "slick.core.js",
   "directories": {

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -2381,6 +2381,17 @@ if (typeof Slick === "undefined") {
           cacheEntry.rowNode.appendChild(node);
           cacheEntry.cellNodesByColumnIdx[columnIdx] = node;
         }
+
+        /**
+         * {{SQL CARBON EDIT}}
+         * sorting the cell nodes inside the row div. This helps us fix the issue of 
+         * screen reader not reading the cell index in the correct order. Issue: https://github.com/microsoft/azuredatastudio/issues/20784
+         */
+        [].slice.call(cacheEntry.rowNode.childNodes).sort(function (a, b) {
+					return a.ariaColIndex - b.ariaColIndex;
+				}).forEach(function (ele) {
+					cacheEntry.rowNode.appendChild(ele);
+				});
       }
     }
 
@@ -2841,6 +2852,9 @@ if (typeof Slick === "undefined") {
             handled = navigateDown();
           } else if (e.which == keyCode.TAB) {
             handled = navigateNext();
+          } else if (e.which == 114) {
+            sortColumnByActiveCell();
+            handled = true;
           } else if (e.which == keyCode.ENTER) {
             if (options.editable) {
               if (currentEditor) {

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -1839,15 +1839,19 @@ if (typeof Slick === "undefined") {
           }
         }
 
-        // Do not render cells outside of the viewport.
-        if (columnPosRight[Math.min(ii - 1, i + colspan - 1)] > range.leftPx) {
-          if (columnPosLeft[i] > range.rightPx) {
-            // All columns to the right are outside the range.
-            break;
-          }
+        // Commenting out this block of code to remove cell based virtualization to prevent screen reader issues. 
+        // // Do not render cells outside of the viewport.
+        // if (columnPosRight[Math.min(ii - 1, i + colspan - 1)] > range.leftPx) {
+        //   if (columnPosLeft[i] > range.rightPx) {
+        //     // All columns to the right are outside the range.
+        //     break;
+        //   }
 
-          appendCellHtml(stringArray, row, i, colspan, d);
-        }
+        //   appendCellHtml(stringArray, row, i, colspan, d);
+        // }
+
+        // Rendering all cells for the given row. 
+        appendCellHtml(stringArray, row, i, colspan, d);
 
         if (colspan > 1) {
           i += (colspan - 1);
@@ -2381,17 +2385,6 @@ if (typeof Slick === "undefined") {
           cacheEntry.rowNode.appendChild(node);
           cacheEntry.cellNodesByColumnIdx[columnIdx] = node;
         }
-
-        /**
-         * {{SQL CARBON EDIT}}
-         * sorting the cell nodes inside the row div. This helps us fix the issue of 
-         * screen reader not reading the cell index in the correct order. Issue: https://github.com/microsoft/azuredatastudio/issues/20784
-         */
-        [].slice.call(cacheEntry.rowNode.childNodes).sort(function (a, b) {
-					return a.ariaColIndex - b.ariaColIndex;
-				}).forEach(function (ele) {
-					cacheEntry.rowNode.appendChild(ele);
-				});
       }
     }
 
@@ -2490,10 +2483,11 @@ if (typeof Slick === "undefined") {
       // remove rows no longer in the viewport
       cleanupRows(rendered);
 
-      // add new rows & missing cells in existing rows
-      if (lastRenderedScrollLeft != scrollLeft) {
-        cleanUpAndRenderCells(rendered);
-      }
+      // since all the cells are rendered for the row, we do not need to re-render missing cells on horizontal scroll
+      // // add new rows & missing cells in existing rows
+      // if (lastRenderedScrollLeft != scrollLeft) {
+      //   cleanUpAndRenderCells(rendered);
+      // }
 
       // render missing rows
       renderRows(rendered);

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -2846,9 +2846,6 @@ if (typeof Slick === "undefined") {
             handled = navigateDown();
           } else if (e.which == keyCode.TAB) {
             handled = navigateNext();
-          } else if (e.which == 114) {
-            sortColumnByActiveCell();
-            handled = true;
           } else if (e.which == keyCode.ENTER) {
             if (options.editable) {
               if (currentEditor) {

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -106,7 +106,7 @@ if (typeof Slick === "undefined") {
       minRowBuffer: 3,
       emulatePagingWhenScrolling: true, // when scrolling off bottom of viewport, place new row at top of viewport
       editorCellNavOnLRKeys: false,
-      disableColumnBasedCellVirtualization: false
+      disableColumnBasedCellVirtualization: false //disables column based cell virtualization and fix screen reader issues. https://github.com/microsoft/azuredatastudio/issues/20784
     };
 
     var columnDefaults = {

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -1839,7 +1839,12 @@ if (typeof Slick === "undefined") {
           }
         }
 
-        // Commenting out this block of code to remove cell based virtualization to prevent screen reader issues. 
+        /**
+         * Commenting out this block of code to remove column based virtualization to prevent screen reader issues. 
+         * Now, cells for all columns are rendered for a given row.
+         * Link to the issue: https://github.com/microsoft/azuredatastudio/issues/20784
+         */
+
         // // Do not render cells outside of the viewport.
         // if (columnPosRight[Math.min(ii - 1, i + colspan - 1)] > range.leftPx) {
         //   if (columnPosLeft[i] > range.rightPx) {


### PR DESCRIPTION
Slickgrid only holds the cell nodes which get shown in the viewport within the row divs (typical virtualization logic). So, if the user is scrolling horizontally in a grid the cells which are now hidden get removed and the new cells are added. 

While we are following the aria guidelines and adding a proper colindex to the cells, the screen readers (NVDA, narrator) are ignoring this detail and reading the first cell node as column 1 regardless of the col index we provide for that cell.

A simple fix for this issue is to disable virtualization on column level for slick grid.  Since, most of the times there are fewer columns than rows disabling this kind of virtualization should not hurt the performance of the overall grid. 

Issue:
https://github.com/microsoft/azuredatastudio/issues/20784
https://github.com/microsoft/azuredatastudio/issues/20780

While this issue is filed for top operations, it can be reproduced everywhere in ADS where slickgrid has many columns. 
