### PR TITLE
Ensure inputString is actually a string

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -1863,7 +1863,7 @@ if (typeof Slick === "undefined") {
     // Function copied from https://github.com/microsoft/azuredatastudio/blob/main/src/sql/base/common/strings.ts#L10
     // Used to prevent execution of HTML in vulnerable areas such as aria-label.
     function htmlEscape(inputString) {
-      inputString = inputString.replace(/[<|>|&|"|\']/g, function (match) {
+      inputString = `${inputString}`.replace(/[<|>|&|"|\']/g, function (match) {
         switch (match) {
           case '<': return '&lt;';
           case '>': return '&gt;';


### PR DESCRIPTION
This PR addresses a bug in Azure Data Studio that is preventing plan tree and top operations from rendering (microsoft/azuredatastudio#23564). The problem is that `replace` is being invoked on the `inputString` parameter when the type is a `number` and not a `string`. Casting it to a string through string interpolation addresses the issue.