### PR TITLE
Fix scroll behavior for multiple result sets

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -307,7 +307,7 @@ if (typeof Slick === "undefined") {
         $headerRowScroller.hide();
       }
 
-      $viewport = $("<div role='presentation' class='slick-viewport' style='width:100%;overflow:auto;outline:0;position:relative;;'>").appendTo($container);
+      $viewport = $("<div role='presentation' class='slick-viewport' style='width:auto;overflow:auto;outline:0;position:absolute;'>").appendTo($container);
 
       $focusAnchor = $("<div tabIndex='0' hideFocus style='position:fixed;width:0;height:0;top:0;left:0;outline:0;'></div>").appendTo($viewport);
 


### PR DESCRIPTION
Partially addresses https://github.com/microsoft/azuredatastudio/issues/21721 and many other related issues with scrolling of multiple results.

The remaining issue is in the render method of _scrollableView_ class that often leads to console error when scrolling fails.. I will open a new issue for that one.
