### PR TITLE
Fixing legacy deps causing conflicts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slickgrid",
-  "version": "2.3.50",
+  "version": "2.3.51",
   "description": "A lightning fast JavaScript grid/spreadsheet modified for use in Azure Data Studio",
   "main": "slick.core.js",
   "directories": {
@@ -30,7 +30,6 @@
   },
   "peerDependencies": {
     "jquery": ">=1.8.0",
-    "jquery-ui": ">=1.8.0",
-    "jquery.event.drag": ">=2.3.0"
+    "jquery-ui": ">=1.8.0"
   }
 }


### PR DESCRIPTION
Description:
This change fixes the SlickGrid.ADS package metadata by removing the invalid jquery.event.drag peer dependency and bumping the package version to 2.3.51.

Why:
The package was declaring jquery.event.drag >=2.3.0 as a peer dependency, but that version is not available on npm. This caused downstream installs to require a workaround even though SlickGrid.ADS already includes the drag script in its packaged assets.